### PR TITLE
Missing Doxygen Documentation

### DIFF
--- a/cpptest/src/compileroutput.cpp
+++ b/cpptest/src/compileroutput.cpp
@@ -61,7 +61,7 @@ namespace Test
 	/// \param format Pre-defined compiler output format.
 	/// \param stream Stream to output to.
 	///
-	CompilerOutput::CompilerOutput(Format format, ostream& stream)
+	CompilerOutput::CompilerOutput(Format format, std::ostream& stream)
 	:	Output(),
 		_stream(stream)
 	{
@@ -83,7 +83,7 @@ namespace Test
 	///
 	/// \exception InvalidFormat Invalid format specified.
 	///
-	CompilerOutput::CompilerOutput(const string& format, ostream& stream)
+	CompilerOutput::CompilerOutput(const std::string& format, std::ostream& stream)
 	:	Output(),
 		_format(format),
 		_stream(stream)


### PR DESCRIPTION
Running Doxygen on the code results in the following warnings:

``.../src/compileroutput.cpp:64: warning: no matching class member found for
  Test::CompilerOutput::CompilerOutput(Test::CompilerOutput::Format format, ostream &stream)
Possible candidates:
  Test::CompilerOutput::CompilerOutput(Format format=Generic, std::ostream &stream=std::cout)
  Test::CompilerOutput::CompilerOutput(const std::string &format, std::ostream &stream=std::cout)``

``.../src/compileroutput.cpp:86: warning: no matching class member found for
  Test::CompilerOutput::CompilerOutput(const  string &format, ostream &stream)
Possible candidates:
  Test::CompilerOutput::CompilerOutput(Format format=Generic, std::ostream &stream=std::cout)
  Test::CompilerOutput::CompilerOutput(const std::string &format, std::ostream &stream=std::cout)``

This fixes these warnings.