### PR TITLE
Build shared library on cygwin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,7 +33,7 @@ AM_CXXFLAGS		= $(WARN_FLAGS)
 
 lib_LTLIBRARIES		= libcpptest.la
 
-libcpptest_la_LDFLAGS	= -version-info $(LT_VERSION)
+libcpptest_la_LDFLAGS	= -no-undefined -version-info $(LT_VERSION)
 
 libcpptest_la_SOURCES	= \
 	collectoroutput.cpp \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.0-1.x86_64 2024-02-01 11:02 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/cpptest/cpptest.git
$ cd cpptest
$ ./autogen.sh
$ ./configure --enable-shared --disable-static
$ make V=1
: 
/bin/sh ../libtool  --tag=CXX   --mode=link g++ -std=c++11   -g -O2 -version-info 1:8:0  -o libcpptest.la -rpath /usr/local/lib collectoroutput.lo compileroutput.lo htmloutput.lo missing.lo source.lo suite.lo textoutput.lo time.lo utils.lo
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!