### PR TITLE
linux.yml: Start using Clang/LLVM from ubuntu-24.04 to fix CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,23 +25,13 @@ jobs:
           - cc: gcc-14
             cxx: g++-14
             clang_major_version: null
-            clang_repo_suffix: null
             upload: true
           - cc: clang-18
             cxx: clang++-18
             clang_major_version: 18
-            clang_repo_suffix: -18
     steps:
       - name: Checkout Git branch
         uses: actions/checkout@v4
-
-      - name: Add Clang/LLVM repositories
-        if: "${{ contains(matrix.cxx, 'clang') }}"
-        run: |-
-          set -x
-          source /etc/os-release
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}${{ matrix.clang_repo_suffix }} main"
 
       - name: Install build dependencies
         run: |-


### PR DESCRIPTION
.. to fix Doxygen invocation issue.

Symptom was:
> make[1]: Entering directory '/home/runner/work/cpptest/cpptest/build/doc'
> doxygen
> doxygen: error while loading shared libraries: libLLVM.so.18.1: cannot open shared object file: No such file or directory